### PR TITLE
fix #3 error when exporting non-string literals

### DIFF
--- a/src/transformers/__testfixtures__/import-declaration-transform.input.js
+++ b/src/transformers/__testfixtures__/import-declaration-transform.input.js
@@ -4,6 +4,8 @@ import foo from './foo';
 export * from './bar';
 export {default as bar} from './bar';
 export {default as foo} from './foo';
+export const num = 1;
+export const filePath = './bar';
 
 bar();
 foo();

--- a/src/transformers/__testfixtures__/import-declaration-transform.output.js
+++ b/src/transformers/__testfixtures__/import-declaration-transform.output.js
@@ -5,7 +5,7 @@ export * from './new/path/to/bar';
 export {default as bar} from './new/path/to/bar';
 export {default as foo} from './new/path/to/foo';
 export const num = 1;
-export const filePath = './new/path/to/bar';
+export const filePath = './bar';
 
 bar();
 foo();

--- a/src/transformers/__testfixtures__/import-declaration-transform.output.js
+++ b/src/transformers/__testfixtures__/import-declaration-transform.output.js
@@ -4,6 +4,8 @@ import foo from './new/path/to/foo';
 export * from './new/path/to/bar';
 export {default as bar} from './new/path/to/bar';
 export {default as foo} from './new/path/to/foo';
+export const num = 1;
+export const filePath = './new/path/to/bar';
 
 bar();
 foo();

--- a/src/transformers/__testfixtures__/import-relative-transform.input.js
+++ b/src/transformers/__testfixtures__/import-relative-transform.input.js
@@ -4,6 +4,8 @@ import goo from '../../goo';
 export * from './foo';
 export {default as foo} from './foo';
 export {default as goo} from '../../goo';
+export const num = 1;
+export const filePath = './foo';
 
 foo();
 goo();

--- a/src/transformers/__testfixtures__/import-relative-transform.output.js
+++ b/src/transformers/__testfixtures__/import-relative-transform.output.js
@@ -4,6 +4,8 @@ import goo from './old/goo';
 export * from './old/path/to/foo';
 export {default as foo} from './old/path/to/foo';
 export {default as goo} from './old/goo';
+export const num = 1;
+export const filePath = './foo';
 
 foo();
 goo();

--- a/src/transformers/__testfixtures__/import-specifier-transform-alias.input.js
+++ b/src/transformers/__testfixtures__/import-specifier-transform-alias.input.js
@@ -1,4 +1,6 @@
 import {foo as goo} from './bar';
 export {foo as goo} from './bar';
+export const num = 1;
+export const filePath = './bar';
 
 goo();

--- a/src/transformers/__testfixtures__/import-specifier-transform-alias.output.js
+++ b/src/transformers/__testfixtures__/import-specifier-transform-alias.output.js
@@ -1,4 +1,6 @@
 import {fooPrime as goo} from './bar';
 export {fooPrime as goo} from './bar';
+export const num = 1;
+export const filePath = './bar';
 
 goo();

--- a/src/transformers/__testfixtures__/import-specifier-transform.input.js
+++ b/src/transformers/__testfixtures__/import-specifier-transform.input.js
@@ -1,3 +1,5 @@
 import foo from './bar';
+export const num = 1;
+export const filePath = './bar';
 
 foo();

--- a/src/transformers/__testfixtures__/import-specifier-transform.output.js
+++ b/src/transformers/__testfixtures__/import-specifier-transform.output.js
@@ -1,3 +1,5 @@
 import fooPrime from './bar';
+export const num = 1;
+export const filePath = './bar';
 
 fooPrime();

--- a/src/transformers/fileHelpers/filterMatchingPaths.js
+++ b/src/transformers/fileHelpers/filterMatchingPaths.js
@@ -4,12 +4,7 @@ import removeExtension from './removeExtension';
 export default function filterMatchingPaths(basedir, filePath) {
   const normalizedFilePath = removeExtension(filePath);
   return (path) => {
-    const value = path.value.value;
-    if (typeof value !== 'string') {
-      return false;
-    }
-
-    const testPath = removeExtension(resolve(basedir, value));
+    const testPath = removeExtension(resolve(basedir, path.value.value));
     return testPath === normalizedFilePath;
   };
 }

--- a/src/transformers/fileHelpers/filterMatchingPaths.js
+++ b/src/transformers/fileHelpers/filterMatchingPaths.js
@@ -4,7 +4,12 @@ import removeExtension from './removeExtension';
 export default function filterMatchingPaths(basedir, filePath) {
   const normalizedFilePath = removeExtension(filePath);
   return (path) => {
-    const testPath = removeExtension(resolve(basedir, path.value.value));
+    const value = path.value.value;
+    if (typeof value !== 'string') {
+      return false;
+    }
+
+    const testPath = removeExtension(resolve(basedir, value));
     return testPath === normalizedFilePath;
   };
 }

--- a/src/transformers/import-declaration-transform.js
+++ b/src/transformers/import-declaration-transform.js
@@ -28,6 +28,7 @@ export default function importDeclarationTransform(file, api, options) {
 
   const exportDeclarations = root
     .find(j.ExportNamedDeclaration)
+    .filter((path) => path.value.source !== null)
     .find(j.Literal);
 
   const exportAllDeclarations = root

--- a/src/transformers/import-relative-transform.js
+++ b/src/transformers/import-relative-transform.js
@@ -41,6 +41,7 @@ export default function importRelativeTransform(file, api, options) {
 
   const exportDeclarations = root
     .find(j.ExportNamedDeclaration)
+    .filter((path) => path.value.source !== null)
     .find(j.Literal)
     .filter(filterNonRelativePaths);
 

--- a/src/transformers/import-specifier-transform.js
+++ b/src/transformers/import-specifier-transform.js
@@ -29,6 +29,7 @@ export default function importSpecifierTransform(file, api, options) {
 
   const exportDeclarations = root
     .find(j.ExportNamedDeclaration)
+    .filter((path) => path.value.source !== null)
     .find(j.Literal)
     .filter(matchesPath);
 


### PR DESCRIPTION
Fixes #3 

I'm not sure if it's intentional that the transform applies to all exported values, but I could see a scenario where someone is relying on that behavior. For example, if they are exporting file paths as strings. So, I opted to keep that functionality and added a test for it.

Totally open to suggestions if there's a better way to handle this.